### PR TITLE
don't force clearable when target=self

### DIFF
--- a/src/services/render.js
+++ b/src/services/render.js
@@ -23,7 +23,7 @@ Render.prototype.main = function () {
   let that = this
   let { h, self } = that
   let isReadonly = self.target === 'self' || !!self.displayValue
-  let isClearable = !!self.values.input && (self.target === 'self' || self.clearable)
+  let isClearable = !!self.values.input && self.clearable
   let component = isReadonly ? QField : QInput
 
   let children = []


### PR DESCRIPTION
I'm uncertain if there's an internal reason why when target=self then clearable is forced on.

I'd like to use target=self and NOT allow users to clear the field entirely. Basically I want users to only be able to change the date but not blank it out.